### PR TITLE
Add file output flag to wget gui-docker command. (#214)

### DIFF
--- a/install/docker/index.markdown
+++ b/install/docker/index.markdown
@@ -33,7 +33,7 @@ And you will likely need to log out and back into your user account for the chan
 
 To run a Debian-installed container of MoveIt! with graphics support:
 
-    wget https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/.docker/gui-docker gui-docker && chmod +x gui-docker
+    wget https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/.docker/gui-docker -O gui-docker && chmod +x gui-docker
     ./gui-docker -it --rm moveit/moveit:kinetic-release /bin/bash
 
 This will attempt to use nvidia-docker if hardware and drivers are available.


### PR DESCRIPTION
Without the -O flag, wget tries to parse "gui-docker" as a file to get not an output file name.